### PR TITLE
IE <= 8: Window will have no hasOwnProperty method, errors out.

### DIFF
--- a/lib/mmd-test-spec.js
+++ b/lib/mmd-test-spec.js
@@ -48,7 +48,7 @@ describe("Micro Module Definition (MMD)", function() {
 		try {
 			mmd.define();
 		} catch (e) {
-			console.log(e);
+			//console.log(e);
 		}
 	});
 	
@@ -132,7 +132,7 @@ describe("Micro Module Definition (MMD)", function() {
 		try {
 			mmd.require( 'undefined-module' );
 		} catch (e) {
-			console.log(e);
+			//console.log(e);
 		}
 	});
 	
@@ -270,7 +270,24 @@ describe("Micro Module Definition (MMD)", function() {
 		try {
 			mmd.require( 'circ.3' );
 		} catch (e) {
-			console.log(e);
+			//console.log(e);
 		}
+	});
+
+	// 10) Require and define as globals
+	it('should resolve module dependencies in the global window context', function() {
+		window.require = mmd.require;
+		window.define = mmd.define;
+
+		var content = "module content";
+		
+		// Define a simple module which returns the "content" value.
+		define('global', function() {
+			return content;
+		});
+		
+		require( 'global', function( injected ) {
+			expect( injected ).toBe( content );
+		});
 	});
 });

--- a/mmd.js
+++ b/mmd.js
@@ -53,7 +53,7 @@ var mmd = (function(modules, api) {
 					// Populate with self.
 					req[ i ] = api;
 					
-				} else if (self.hasOwnProperty.call( modules, id )) {
+				} else if (Object.prototype.hasOwnProperty.call( modules, id )) {
 					// Known module reference:
 					// Pull module definition from key table.
 					mod = modules[ id ];


### PR DESCRIPTION
When using require and define from the window object (via window.require = mmd.require), self.hasOwnProperty.call will fail in IE before version 9.

Pull request resolves this issue by using Object.prototype.hasOwnProperty.call instead, and adds a jasmine test.
